### PR TITLE
ruby 2 compat -- .methods returns symbols

### DIFF
--- a/lib/mysql_binlog/binlog.rb
+++ b/lib/mysql_binlog/binlog.rb
@@ -81,7 +81,7 @@ module MysqlBinlog
     def read_event_fields(header)
       # Delegate the parsing of the event content to a method of the same name
       # in BinlogEventParser.
-      if event_parser.methods.map(&:to_s).include? header[:event_type].to_s
+      if event_parser.methods.map(&:to_sym).include? header[:event_type]
         fields = event_parser.send(header[:event_type], header)
       end
 


### PR DESCRIPTION
fixes running the mysql_binlog gem under ruby 2.
