### PR TITLE
Add support for master_data_written query event status type

### DIFF
--- a/lib/mysql_binlog/binlog_event_parser.rb
+++ b/lib/mysql_binlog/binlog_event_parser.rb
@@ -303,6 +303,8 @@ module MysqlBinlog
           parser.read_uint16
         when :table_map_for_update
           parser.read_uint64
+        when :master_data_written
+          parser.read_uint32
         when :updated_db_names
           _query_event_status_updated_db_names
         when :commit_ts


### PR DESCRIPTION
This is 4 byte bitfield:

https://github.com/mysql/mysql-server/blob/mysql-8.0.27/libbinlogevents/include/statement_events.h#L354-L366

    <td>master_data_written</td>
    <td>Q_MASTER_DATA_WRITTEN_CODE == 10</td>
    <td>4 byte bitfield</td>

    <td>The value of the original length of a Query_event that comes from a
    master. Master's event is relay-logged with storing the original size of
    event in this field by the IO thread. The size is to be restored by reading
    Q_MASTER_DATA_WRITTEN_CODE-marked event from the relay log.

    This field is not written to slave's server binlog by the SQL thread.
    This field only exists in relay logs where master has binlog_version<4 i.e.
    server_version < 5.0 and the slave has binlog_version=4.
    </td>