### PR TITLE
Add support for invoker query event status type

### DIFF
--- a/lib/mysql_binlog/binlog_event_parser.rb
+++ b/lib/mysql_binlog/binlog_event_parser.rb
@@ -303,6 +303,11 @@ module MysqlBinlog
           parser.read_uint16
         when :table_map_for_update
           parser.read_uint64
+        when :invoker
+          {
+            :user => parser.read_lpstring,
+            :host => parser.read_lpstring,
+          }
         when :updated_db_names
           _query_event_status_updated_db_names
         when :commit_ts


### PR DESCRIPTION
This is 2 variable-length strings:

https://github.com/mysql/mysql-server/blob/mysql-8.0.27/libbinlogevents/include/statement_events.h#L369-L383

    <td>binlog_invoker</td>
    <td>Q_INVOKER == 11</td>
    <td>2 Variable-length strings: the length in bytes (1 byte) followed
    by characters (user), again followed by length in bytes (1 byte) followed
    by characters(host)</td>

    <td>The value of boolean variable m_binlog_invoker is set TRUE if
    CURRENT_USER() is called in account management statements. SQL thread
    uses it as a default definer in CREATE/ALTER SP, SF, Event, TRIGGER or
    VIEW statements.

    The field Q_INVOKER has length of user stored in 1 byte followed by the
    user string which is assigned to 'user' and the length of host stored in
    1 byte followed by host string which is assigned to 'host'.
    </td>