### PR TITLE
Add support for explicit_defaults_for_timestamp query event status type

### DIFF
--- a/lib/mysql_binlog/binlog_event_parser.rb
+++ b/lib/mysql_binlog/binlog_event_parser.rb
@@ -101,7 +101,7 @@ module MysqlBinlog
     :microseconds,              # 13 (Q_MICROSECONDS)
     :commit_ts,                 # 14 (Q_COMMIT_TS)
     :commit_ts2,                # 15
-    :explicit_defaults_for_timestamp, # 16
+    :explicit_defaults_for_timestamp, # 16 (Q_EXPLICIT_DEFAULTS_FOR_TIMESTAMP)
   ]
 
   QUERY_EVENT_OVER_MAX_DBS_IN_EVENT_MTS = 254
@@ -316,6 +316,8 @@ module MysqlBinlog
           parser.read_uint64
         when :microseconds
           parser.read_uint24
+        when :explicit_defaults_for_timestamp
+          parser.read_uint8
         else
           raise "Unknown status type #{status_type_id}"
         end


### PR DESCRIPTION
`explicit_defaults_for_timestamp` is 1 byte bitfield:

https://github.com/mysql/mysql-server/blob/mysql-8.0.27/libbinlogevents/include/statement_events.h#L394-L400

    <td>explicit_defaults_ts</td>
    <td>Q_EXPLICIT_DEFAULTS_FOR_TIMESTAMP</td>
    <td>1 byte boolean</td>
    <td>Stores master connection @@session.explicit_defaults_for_timestamp when
    CREATE and ALTER operate on a table with a TIMESTAMP column. </td>

https://github.com/mysql/mysql-server/blob/mysql-8.0.27/libbinlogevents/src/statement_events.cpp#L312